### PR TITLE
Fix module name references for receipt report

### DIFF
--- a/models/ledger.py
+++ b/models/ledger.py
@@ -32,7 +32,7 @@ class VeresiyeDefteri(models.Model):
             record.last_entry_date = max(dates) if dates else False
 
     def print_receipt(self):
-        return self.env.ref("veresiye_defteri.report_veresiye_receipt").report_action(self)
+        return self.env.ref("veresiyedefteri.report_veresiye_receipt").report_action(self)
 
     def action_open_payment_wizard(self):
         self.ensure_one()

--- a/report/receipt_report.xml
+++ b/report/receipt_report.xml
@@ -13,8 +13,8 @@
         </record>
 
         <report id="report_veresiye_receipt" model="veresiye.defteri" string="Veresiye Fişi"
-                report_type="qweb-pdf" name="veresiye_defteri.report_receipt"
-                file="veresiye_defteri.report_receipt" paperformat="paperformat_veresiye"/>
+                report_type="qweb-pdf" name="veresiyedefteri.report_receipt"
+                file="veresiyedefteri.report_receipt" paperformat="paperformat_veresiye"/>
 
         <template id="report_receipt">
             <t t-call="web.basic_layout">


### PR DESCRIPTION
## Summary
- Use correct module name in receipt printing code
- Align report XML references with actual module name

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a76eee59808323826c065d749ca00d