### PR TITLE
Add save-and-close action and auto-fill product price

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-from . import models
-from . import wizard
+from . import models  # noqa: F401
+from . import wizard  # noqa: F401

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,2 +1,2 @@
-from . import ledger
-from . import res_partner
+from . import ledger  # noqa: F401
+from . import res_partner  # noqa: F401

--- a/models/ledger.py
+++ b/models/ledger.py
@@ -5,15 +5,31 @@ class VeresiyeDefteri(models.Model):
     _name = 'veresiye.defteri'
     _description = 'Veresiye Defteri'
 
-    partner_id = fields.Many2one('res.partner', string='Müşteri', required=True)
-    phone = fields.Char(related='partner_id.phone', store=True, string='Telefon')
-    date = fields.Date(default=fields.Date.context_today, string='Tarih')
-    line_ids = fields.One2many('veresiye.defteri.line', 'ledger_id', string='Satırlar')
-    total_amount = fields.Monetary(compute='_compute_totals', store=True, string='Borç Tutarı')
+    partner_id = fields.Many2one(
+        'res.partner', string='Müşteri', required=True
+    )
+    phone = fields.Char(
+        related='partner_id.phone', store=True, string='Telefon'
+    )
+    date = fields.Date(
+        default=fields.Date.context_today, string='Tarih'
+    )
+    line_ids = fields.One2many(
+        'veresiye.defteri.line', 'ledger_id', string='Satırlar'
+    )
+    total_amount = fields.Monetary(
+        compute='_compute_totals', store=True, string='Borç Tutarı'
+    )
     paid_amount = fields.Monetary(string='Ödenen', default=0.0)
-    remaining_amount = fields.Monetary(compute='_compute_remaining', store=True, string='Kalan')
-    currency_id = fields.Many2one('res.currency', default=lambda self: self.env.company.currency_id)
-    last_entry_date = fields.Date(compute='_compute_last_entry', store=True, string='En Son Tarih')
+    remaining_amount = fields.Monetary(
+        compute='_compute_remaining', store=True, string='Kalan'
+    )
+    currency_id = fields.Many2one(
+        'res.currency', default=lambda self: self.env.company.currency_id
+    )
+    last_entry_date = fields.Date(
+        compute='_compute_last_entry', store=True, string='En Son Tarih'
+    )
 
     @api.depends('line_ids.subtotal')
     def _compute_totals(self):
@@ -32,7 +48,10 @@ class VeresiyeDefteri(models.Model):
             record.last_entry_date = max(dates) if dates else False
 
     def print_receipt(self):
-        return self.env.ref("veresiyedefteri.report_veresiye_receipt").report_action(self)
+        action = self.env.ref(
+            "veresiyedefteri.action_report_veresiye_receipt"
+        )
+        return action.report_action(self)
 
     def action_open_payment_wizard(self):
         self.ensure_one()
@@ -45,19 +64,44 @@ class VeresiyeDefteri(models.Model):
             'context': {'default_ledger_id': self.id},
         }
 
+    def action_save_and_close(self):
+        """Save the record and return to the tree view."""
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'veresiye.defteri',
+            'view_mode': 'tree,form',
+            'target': 'current',
+        }
 
 
 class VeresiyeDefteriLine(models.Model):
     _name = 'veresiye.defteri.line'
     _description = 'Veresiye Defteri Satırı'
 
-    ledger_id = fields.Many2one('veresiye.defteri', string='Defter', required=True, ondelete='cascade')
-    product_id = fields.Many2one('product.product', string='Ürün', required=True)
+    ledger_id = fields.Many2one(
+        'veresiye.defteri', string='Defter', required=True, ondelete='cascade'
+    )
+    product_id = fields.Many2one(
+        'product.product', string='Ürün', required=True
+    )
     quantity = fields.Float(string='Adet', default=1.0)
     price_unit = fields.Monetary(string='Fiyat', required=True)
-    subtotal = fields.Monetary(compute='_compute_subtotal', store=True, string='Ara Toplam')
-    date = fields.Date(default=fields.Date.context_today, string='Tarih')
-    currency_id = fields.Many2one('res.currency', related='ledger_id.currency_id', store=True)
+    subtotal = fields.Monetary(
+        compute='_compute_subtotal', store=True, string='Ara Toplam'
+    )
+    date = fields.Date(
+        default=fields.Date.context_today, string='Tarih'
+    )
+    currency_id = fields.Many2one(
+        'res.currency', related='ledger_id.currency_id', store=True
+    )
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        """Set the unit price when a product is selected."""
+        for line in self:
+            if line.product_id:
+                line.price_unit = line.product_id.list_price
 
     @api.depends('quantity', 'price_unit')
     def _compute_subtotal(self):

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -4,13 +4,32 @@ from odoo import api, fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    veresiye_ledger_ids = fields.One2many('veresiye.defteri', 'partner_id', string='Veresiye Defteri')
-    currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)
-    veresiye_total_amount = fields.Monetary(compute='_compute_veresiye_amounts', currency_field='currency_id', string='Borç')
-    veresiye_paid_amount = fields.Monetary(compute='_compute_veresiye_amounts', currency_field='currency_id', string='Ödenen')
-    veresiye_remaining_amount = fields.Monetary(compute='_compute_veresiye_amounts', currency_field='currency_id', string='Kalan')
+    veresiye_ledger_ids = fields.One2many(
+        'veresiye.defteri', 'partner_id', string='Veresiye Defteri'
+    )
+    currency_id = fields.Many2one(
+        'res.currency', related='company_id.currency_id', readonly=True
+    )
+    veresiye_total_amount = fields.Monetary(
+        compute='_compute_veresiye_amounts',
+        currency_field='currency_id',
+        string='Borç',
+    )
+    veresiye_paid_amount = fields.Monetary(
+        compute='_compute_veresiye_amounts',
+        currency_field='currency_id',
+        string='Ödenen',
+    )
+    veresiye_remaining_amount = fields.Monetary(
+        compute='_compute_veresiye_amounts',
+        currency_field='currency_id',
+        string='Kalan',
+    )
 
-    @api.depends('veresiye_ledger_ids.total_amount', 'veresiye_ledger_ids.paid_amount')
+    @api.depends(
+        'veresiye_ledger_ids.total_amount',
+        'veresiye_ledger_ids.paid_amount',
+    )
     def _compute_veresiye_amounts(self):
         for partner in self:
             total = sum(partner.veresiye_ledger_ids.mapped('total_amount'))

--- a/report/receipt_report.xml
+++ b/report/receipt_report.xml
@@ -12,9 +12,11 @@
             <field name="margin_right">5</field>
         </record>
 
-        <report id="report_veresiye_receipt" model="veresiye.defteri" string="Veresiye Fişi"
-                report_type="qweb-pdf" name="veresiyedefteri.report_receipt"
-                file="veresiyedefteri.report_receipt" paperformat="paperformat_veresiye"/>
+        <report id="action_report_veresiye_receipt" model="veresiye.defteri"
+                string="Veresiye Fişi" report_type="qweb-pdf"
+                name="veresiyedefteri.report_receipt"
+                file="veresiyedefteri.report_receipt"
+                paperformat="paperformat_veresiye"/>
 
         <template id="report_receipt">
             <t t-call="web.basic_layout">

--- a/views/ledger_views.xml
+++ b/views/ledger_views.xml
@@ -24,7 +24,8 @@
             <field name="arch" type="xml">
                 <form>
                     <header>
-                        <button name="print_receipt" type="object" string="Yazdır Fiş" class="btn-primary"/>
+                        <button name="action_save_and_close" type="object" string="Kaydet" class="btn-primary"/>
+                        <button name="print_receipt" type="object" string="Yazdır Fiş" class="btn-secondary"/>
                         <button name="action_open_payment_wizard" type="object" string="Ödeme Yap" class="btn-secondary"/>
                         <field name="total_amount" readonly="1"/>
                     </header>
@@ -42,7 +43,7 @@
                                     <tree editable="bottom">
                                         <field name="product_id"/>
                                         <field name="quantity" sum="Toplam"/>
-                                        <field name="price_unit"/>
+                                        <field name="price_unit" sum="Toplam"/>
                                         <field name="subtotal" sum="Toplam" readonly="1"/>
                                         <field name="date"/>
                                     </tree>

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -1,1 +1,1 @@
-from . import payment_wizard
+from . import payment_wizard  # noqa: F401

--- a/wizard/payment_wizard.py
+++ b/wizard/payment_wizard.py
@@ -1,13 +1,17 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class VeresiyePaymentWizard(models.TransientModel):
     _name = 'veresiye.payment.wizard'
     _description = 'Ödeme Yap'
 
-    ledger_id = fields.Many2one('veresiye.defteri', string='Defter', required=True)
+    ledger_id = fields.Many2one(
+        'veresiye.defteri', string='Defter', required=True
+    )
     amount = fields.Monetary(string='Ödeme Tutarı', required=True)
-    currency_id = fields.Many2one('res.currency', related='ledger_id.currency_id', readonly=True)
+    currency_id = fields.Many2one(
+        'res.currency', related='ledger_id.currency_id', readonly=True
+    )
 
     def action_confirm(self):
         self.ensure_one()


### PR DESCRIPTION
## Summary
- add button to save a ledger entry and return to list view
- auto-populate line price when selecting a product
- display totals for price and subtotal in entry lines
- fix missing receipt report by renaming action and updating reference

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile ok'`
- `python -m flake8 && echo 'flake8 succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_68a8e24693008323990ab169b5cb2746